### PR TITLE
Dynamic building grid

### DIFF
--- a/packages/client/src/Multiplayer.ts
+++ b/packages/client/src/Multiplayer.ts
@@ -256,7 +256,7 @@ export class MatchControl extends AbstractControl {
 
     moveCommand(unitIds: UnitId[], target: Position, shift: boolean) {
         const cmd : CommandPacket = {
-            action: {
+            command: {
                 typ: 'Move',
                 target
             },
@@ -268,7 +268,7 @@ export class MatchControl extends AbstractControl {
 
     stopCommand(unitIds: UnitId[]) {
         const cmd : CommandPacket = {
-            action: {
+            command: {
                 typ: 'Stop',
             },
             unitIds,
@@ -279,7 +279,7 @@ export class MatchControl extends AbstractControl {
 
     followCommand(unitIds: UnitId[], target: UnitId, shift: boolean) {
         const cmd : CommandPacket = {
-            action: {
+            command: {
                 typ: 'Follow',
                 target
             },
@@ -291,10 +291,10 @@ export class MatchControl extends AbstractControl {
 
     attackCommand(unitIds: UnitId[], target: UnitId, shift: boolean) {
         const cmd : CommandPacket = {
-            action: {
-            typ: 'Attack',
-            target
-        },
+            command: {
+                typ: 'Attack',
+                target
+            },
             unitIds,
             shift,
         };
@@ -303,10 +303,10 @@ export class MatchControl extends AbstractControl {
 
     attackMoveCommand(unitIds: UnitId[], target: Position, shift: boolean) {
         const cmd : CommandPacket = {
-            action: {
-            typ: 'AttackMove',
-            target
-        },
+            command: {
+                typ: 'AttackMove',
+                target
+            },
             unitIds,
             shift,
         };
@@ -315,10 +315,10 @@ export class MatchControl extends AbstractControl {
 
     produceCommand(unitIds: UnitId[], unitToProduce: string) {
         const cmd : CommandPacket = {
-            action: {
-            typ: 'Produce',
-            unitToProduce
-        },
+            command: {
+                typ: 'Produce',
+                unitToProduce
+            },
             unitIds,
             shift: false,
         };
@@ -327,11 +327,11 @@ export class MatchControl extends AbstractControl {
 
     buildCommand(unitIds: UnitId[], building: string, position: Position, shift: boolean) {
         const cmd : CommandPacket = {
-            action: {
-            typ: 'Build',
-            building,
-            position
-        },
+            command: {
+                typ: 'Build',
+                building,
+                position
+            },
             unitIds,
             shift,
         };
@@ -340,10 +340,10 @@ export class MatchControl extends AbstractControl {
 
     harvestCommand(unitIds: UnitId[], target: UnitId, shift: boolean) {
         const cmd : CommandPacket = {
-            action: {
-            typ: 'Harvest',
-            target,
-        },
+            command: {
+                typ: 'Harvest',
+                target,
+            },
             unitIds,
             shift,
         };

--- a/packages/client/src/Multiplayer.ts
+++ b/packages/client/src/Multiplayer.ts
@@ -1,5 +1,5 @@
 import geckos, { Data, ClientChannel } from '@geckos.io/client'
-import { Game, CommandPacket, IdentificationPacket, UpdatePacket, UnitId, Position } from '@bananu7-rts/server/src/types'
+import { Game, MatchMetadata, CommandPacket, IdentificationPacket, UpdatePacket, UnitId, Position } from '@bananu7-rts/server/src/types'
 import { HTTP_API_URL, GECKOS_URL, GECKOS_PORT } from './config'
 
 export type OnChatMessage = (msg: string) => void;
@@ -177,9 +177,15 @@ class AbstractControl {
     protected channel?: ClientChannel;
     protected leaveMatchHandler?: () => void;
 
-    async getMatchState() {
-        console.log("[multiplayer] Getting match state");
-        return fetch(`${HTTP_API_URL}/getMatchState?` + new URLSearchParams({ matchId: this.matchId })).then(r => r.json());
+    async debugGetMatchState() {
+        console.log("[multiplayer] Getting debug match state");
+        return fetch(`${HTTP_API_URL}/debugGetMatchState?` + new URLSearchParams({ matchId: this.matchId })).then(r => r.json());
+    }
+
+    async getMatchMetadata(): Promise<MatchMetadata> {
+        console.log("[multiplayer] Getting match metadata");
+        // TODO - API urls should be in shared constants
+        return fetch(`${HTTP_API_URL}/getMatchMetadata?` + new URLSearchParams({ matchId: this.matchId })).then(r => r.json());
     }
 
     protected _getChannel(): ClientChannel {

--- a/packages/client/src/components/BottomUnitView.tsx
+++ b/packages/client/src/components/BottomUnitView.tsx
@@ -1,10 +1,10 @@
-import { Game, CommandPacket, IdentificationPacket, UpdatePacket, UnitId, Unit, UnitState, Position, ProductionFacility, Hp, Builder } from '@bananu7-rts/server/src/types'
+import { Game, CommandPacket, IdentificationPacket, UpdatePacket, UnitId, Unit, Position, ProductionFacility, Hp, Builder } from '@bananu7-rts/server/src/types'
 import { Multiplayer } from '../Multiplayer'
 
 type Props = {
     selectedUnits: Set<UnitId>,
     setSelectedUnits: (us: Set<UnitId>) => void,
-    units: UnitState[],
+    units: Unit[],
     ownerIndex: number,
 }
 
@@ -22,7 +22,7 @@ export function BottomUnitView (props: Props) {
             return (<SingleUnitView unit={u} owned={owned}/>);
         } else {
             // TODO duplication with CommandPalette
-            const units: UnitState[] = 
+            const units: Unit[] = 
                 Array.from(props.selectedUnits)
                 .map(id => {
                     const unit = props.units.find(u => u.id === id);
@@ -89,7 +89,7 @@ function ProductionProgressBar(props: {percent: number}) {
 }
 
 
-function SingleUnitView(props: {unit: UnitState, owned: boolean}) {
+function SingleUnitView(props: {unit: Unit, owned: boolean}) {
     const health = props.unit.components.find(c => c.type === "Hp") as Hp | undefined;
 
     const productionComponent = props.unit.components.find(c => c.type === "ProductionFacility") as ProductionFacility;
@@ -110,17 +110,13 @@ function SingleUnitView(props: {unit: UnitState, owned: boolean}) {
             <h2>{props.unit.kind}</h2>
             { health && <HealthBar hp={health.hp} maxHp={health.maxHp} /> }
             { health && <h3>{health.hp}/{health.maxHp}</h3> }
-            {/*<span>{props.unit.id}</span><br/>
-            <span>{props.unit.position.x}</span><br/>
-            <span>{props.unit.position.y}</span>*/}
-            { props.owned && <span>{props.unit.status}</span> }
             { props.owned && productionProgress && <ProductionProgressBar percent={productionProgress} /> }
         </div>
     );
 }
 
 // TODO select on click
-function UnitIcon(props: {unit: UnitState, onClick: (e: React.MouseEvent<HTMLElement>) => void}) {
+function UnitIcon(props: {unit: Unit, onClick: (e: React.MouseEvent<HTMLElement>) => void}) {
     const u = props.unit;
 
     // TODO component getters to shared code
@@ -138,7 +134,7 @@ function UnitIcon(props: {unit: UnitState, onClick: (e: React.MouseEvent<HTMLEle
 }
 
 type MultiUnitViewProps = {
-    units: UnitState[];
+    units: Unit[];
     select: (id: UnitId) => void;
     deselect: (id: UnitId) => void;
 }

--- a/packages/client/src/components/BottomUnitView.tsx
+++ b/packages/client/src/components/BottomUnitView.tsx
@@ -110,9 +110,9 @@ function SingleUnitView(props: {unit: UnitState, owned: boolean}) {
             <h2>{props.unit.kind}</h2>
             { health && <HealthBar hp={health.hp} maxHp={health.maxHp} /> }
             { health && <h3>{health.hp}/{health.maxHp}</h3> }
-            <span>{props.unit.id}</span><br/>
+            {/*<span>{props.unit.id}</span><br/>
             <span>{props.unit.position.x}</span><br/>
-            <span>{props.unit.position.y}</span>
+            <span>{props.unit.position.y}</span>*/}
             { props.owned && <span>{props.unit.status}</span> }
             { props.owned && productionProgress && <ProductionProgressBar percent={productionProgress} /> }
         </div>

--- a/packages/client/src/components/CommandPalette.tsx
+++ b/packages/client/src/components/CommandPalette.tsx
@@ -5,7 +5,6 @@ import {
    UpdatePacket,
    UnitId,
    Unit,
-   UnitState,
    Position,
    ProductionFacility,
    Builder,
@@ -44,7 +43,7 @@ type Props = {
     selectedUnits: Set<UnitId>,
     selectedAction: SelectedAction | undefined,
     setSelectedAction: (a: SelectedAction | undefined) => void,
-    units: UnitState[],
+    units: Unit[],
     ctrl: MatchControl,
     ownerIndex: number,
     notify: (text: string) => void,
@@ -54,7 +53,7 @@ export function CommandPalette(props: Props) {
         return <div></div>;
     }
 
-    const units: UnitState[] = 
+    const units: Unit[] = 
         Array.from(props.selectedUnits)
         .map(id => {
             const unit = props.units.find(u => u.id === id);

--- a/packages/client/src/components/CommandPalette.tsx
+++ b/packages/client/src/components/CommandPalette.tsx
@@ -10,7 +10,7 @@ import {
    Builder,
 } from '@bananu7-rts/server/src/types'
 import { MatchControl } from '../Multiplayer'
-import { SelectedAction } from '../game/SelectedAction'
+import { SelectedCommand } from '../game/SelectedCommand'
 
 type ButtonProps = {
     x?: number,
@@ -41,8 +41,8 @@ function Button(props: ButtonProps) {
 type Props = {
     resources: number, // used to check if the player can afford stuff
     selectedUnits: Set<UnitId>,
-    selectedAction: SelectedAction | undefined,
-    setSelectedAction: (a: SelectedAction | undefined) => void,
+    selectedCommand: SelectedCommand | undefined,
+    setSelectedCommand: (a: SelectedCommand | undefined) => void,
     units: Unit[],
     ctrl: MatchControl,
     ownerIndex: number,
@@ -76,7 +76,7 @@ export function CommandPalette(props: Props) {
 
     const stop = () => {
         props.ctrl.stopCommand(Array.from(props.selectedUnits));
-        props.setSelectedAction(undefined);
+        props.setSelectedCommand(undefined);
     }
 
     const productionUnits = (() => {
@@ -143,7 +143,7 @@ export function CommandPalette(props: Props) {
     })();
 
     const build = (building: string, position: Position) =>
-        props.setSelectedAction({ action: 'Build', building });
+        props.setSelectedCommand({ command: 'Build', building });
 
     // TODO - second click to determine position
     const buildButtons = availableBuildings.map(bp => {
@@ -152,9 +152,9 @@ export function CommandPalette(props: Props) {
         const time = Math.floor(bp.buildTime / 1000);
 
         const active = 
-            props.selectedAction &&
-            props.selectedAction.action === 'Build' &&
-            props.selectedAction.building === b || false;
+            props.selectedCommand &&
+            props.selectedCommand.command === 'Build' &&
+            props.selectedCommand.building === b || false;
 
         const canAfford = props.resources >= cost;
 
@@ -187,10 +187,10 @@ export function CommandPalette(props: Props) {
     let hint = "";
     /* TODO - contextual hints disabled for now
     maybe a tutorial mode would help?
-    if (props.selectedAction) {
-        switch (props.selectedAction.action) {
+    if (props.SelectedCommand) {
+        switch (props.SelectedCommand.command) {
             case 'Build':
-                hint = `Left-click on the map to build a ${props.selectedAction.building}.`;
+                hint = `Left-click on the map to build a ${props.SelectedCommand.building}.`;
                 break;
             case 'Move':
                 hint = "Left-click on the map to move, or on a unit to follow it.";
@@ -213,8 +213,8 @@ export function CommandPalette(props: Props) {
                 <Button
                     key="Move"
                     x={1} y={1}
-                    active={props.selectedAction && props.selectedAction.action === 'Move' || false}
-                    onClick={() => props.setSelectedAction({ action: 'Move'})}
+                    active={props.selectedCommand && props.selectedCommand.command === 'Move' || false}
+                    onClick={() => props.setSelectedCommand({ command: 'Move'})}
                 >
                     <span style={{fontSize: "2.3em"}}>➜</span>
                     <span className="tooltip">Move a unit to a specific location or order it to follow a unit.</span>
@@ -226,8 +226,8 @@ export function CommandPalette(props: Props) {
                 <Button
                     key="Harvest"
                     x={1} y={2}
-                    active={props.selectedAction && props.selectedAction.action === 'Harvest' || false}
-                    onClick={() => props.setSelectedAction({ action: 'Harvest'})}
+                    active={props.selectedCommand && props.selectedCommand.command === 'Harvest' || false}
+                    onClick={() => props.setSelectedCommand({ command: 'Harvest'})}
                 >
                     <span style={{fontSize: "2.3em"}}>⛏️</span>
                     <span className="tooltip">Harvest a resource node</span>
@@ -242,7 +242,7 @@ export function CommandPalette(props: Props) {
                 onClick={stop}
             >
                 <span style={{fontSize: "2.3em"}}>✖</span>
-                <span className="tooltip">Stop the current action and all the queued ones.</span>
+                <span className="tooltip">Stop the current command and all the queued ones.</span>
             </Button>
 
             {
@@ -250,8 +250,8 @@ export function CommandPalette(props: Props) {
                 <Button
                     key="attack"
                     x={3} y={1}
-                    active={props.selectedAction && props.selectedAction.action === 'Attack' || false}
-                    onClick={() => props.setSelectedAction({ action: 'Attack'})}
+                    active={props.selectedCommand && props.selectedCommand.command === 'Attack' || false}
+                    onClick={() => props.setSelectedCommand({ command: 'Attack'})}
                 >
                     <span style={{fontSize: "2.3em"}}>⚔️</span>
                     <span className="tooltip">Attack an enemy unit or move towards a point and attack any enemy units on the way</span>

--- a/packages/client/src/components/MatchController.tsx
+++ b/packages/client/src/components/MatchController.tsx
@@ -122,7 +122,7 @@ export function MatchController(props: MatchControllerProps) {
         // TODO send the closest one
         const gridPos = clampToGrid(p);
         // TODO building size
-        const emptyForBuilding = mapEmptyForBuilding(serverState.board.map, 6, gridPos);
+        const emptyForBuilding = mapEmptyForBuilding(serverState.board.map, {size: 6, type: 'Building'}, gridPos);
         if (emptyForBuilding) {
           props.ctrl.buildCommand([selectedUnits.keys().next().value], selectedAction.building, gridPos, shift);
         } else {

--- a/packages/client/src/components/MatchController.tsx
+++ b/packages/client/src/components/MatchController.tsx
@@ -187,10 +187,13 @@ export function MatchController(props: MatchControllerProps) {
         return;
       } else if (selectedCommand.command === 'Move') {
         props.ctrl.followCommand(Array.from(selectedUnits), targetId, shift);
+        setSelectedCommand(undefined);
       } else if (selectedCommand.command === 'Attack') {
         props.ctrl.attackCommand(Array.from(selectedUnits), targetId, shift);
+        setSelectedCommand(undefined);
       } else if (selectedCommand.command === 'Harvest') {
         props.ctrl.harvestCommand(Array.from(selectedUnits), targetId, shift);
+        setSelectedCommand(undefined);
       }
       break;
     case 2:

--- a/packages/client/src/components/MatchController.tsx
+++ b/packages/client/src/components/MatchController.tsx
@@ -2,9 +2,8 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ThreeEvent } from '@react-three/fiber'
 
 import { SelectedCommand } from '../game/SelectedCommand';
-import { canPerformSelectedCommand } from '../game/UnitQuery';
+import { canPerformSelectedCommand, getBuildingSizeFromBuildingName } from '../game/UnitQuery';
 import { clampToGrid } from '../game/Grid';
-
 import { Minimap } from './Minimap';
 import { CommandPalette } from './CommandPalette';
 import { BottomUnitView } from './BottomUnitView';
@@ -122,8 +121,9 @@ export function MatchController(props: MatchControllerProps) {
         // Only send one harvester to build
         // TODO send the closest one
         const gridPos = clampToGrid(p);
-        // TODO building size
-        const emptyForBuilding = mapEmptyForBuilding(matchMetadata.board.map, {size: 6, type: 'Building'}, gridPos);
+
+        const buildingSize = getBuildingSizeFromBuildingName(selectedCommand.building);
+        const emptyForBuilding = mapEmptyForBuilding(matchMetadata.board.map, {size: buildingSize, type: 'Building'}, gridPos);
         if (emptyForBuilding) {
           props.ctrl.buildCommand([selectedUnits.keys().next().value], selectedCommand.building, gridPos, shift);
         } else {

--- a/packages/client/src/components/MatchController.tsx
+++ b/packages/client/src/components/MatchController.tsx
@@ -38,7 +38,7 @@ export function MatchController(props: MatchControllerProps) {
   const leaveMatch = useCallback(async () => {
     await props.ctrl.leaveMatch();
     setLastUpdatePacket(null);
-  }, [props.ctrl, setLastUpdatePacket, setLastUpdatePacket]);
+  }, [props.ctrl]);
 
   const onUpdatePacket = useCallback((p:UpdatePacket) => {
     setLastUpdatePacket(p);
@@ -84,7 +84,7 @@ export function MatchController(props: MatchControllerProps) {
 
       return newSelectedUnits;
     });
-  }, [setLastUpdatePacket, setSelectedUnits]);
+  }, []);
 
   const downloadMatchMetadata = useCallback(() => {
     props.ctrl.getMatchMetadata().then(s => setMatchMetadata(s));

--- a/packages/client/src/components/Minimap.tsx
+++ b/packages/client/src/components/Minimap.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, CSSProperties } from 'react'
-import { Board, UnitState } from '@bananu7-rts/server/src/types'
+import { Board, Unit } from '@bananu7-rts/server/src/types'
 
 type Props = {
     board: Board,
-    units: UnitState[],
+    units: Unit[],
 }
 
 export function Minimap(props: Props) {

--- a/packages/client/src/components/SpectateController.tsx
+++ b/packages/client/src/components/SpectateController.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { ThreeEvent } from '@react-three/fiber'
 
-import { SelectedAction } from '../game/SelectedAction';
-import { canPerformSelectedAction } from '../game/UnitQuery';
+import { SelectedCommand } from '../game/SelectedCommand';
+import { canPerformSelectedCommand } from '../game/UnitQuery';
 
 import { Minimap } from './Minimap';
 import { CommandPalette } from './CommandPalette';
@@ -194,7 +194,7 @@ export function SpectateController(props: SpectateControllerProps) {
               playerIndex={0} // TODO - spectator has no player index
               units={lastUpdatePacket ? lastUpdatePacket.units : []}
               selectedUnits={selectedUnits}
-              selectedAction={undefined} // the board needs selected action to show e.g. build preview
+              selectedCommand={undefined} // the board needs selected command to show e.g. build preview
               select={boardSelectUnits}
               mapClick={mapClick}
               unitClick={unitClick}

--- a/packages/client/src/components/SpectateController.tsx
+++ b/packages/client/src/components/SpectateController.tsx
@@ -36,7 +36,7 @@ export function SpectateController(props: SpectateControllerProps) {
     await props.ctrl.stopSpectating();
     setLastUpdatePacket(null);
     setMatchMetadata(null);
-  }, [props.ctrl, setLastUpdatePacket, setMatchMetadata]);
+  }, [props.ctrl]);
 
   const onUpdatePacket = useCallback((p:UpdatePacket) => {
     setLastUpdatePacket(p);
@@ -48,7 +48,7 @@ export function SpectateController(props: SpectateControllerProps) {
       );
       return newSelectedUnits;
     });
-  }, [setLastUpdatePacket, setSelectedUnits]);
+  }, []);
 
   const downloadMatchMetadata = useCallback(() => {
     props.ctrl.getMatchMetadata()

--- a/packages/client/src/debug/DebugApp.tsx
+++ b/packages/client/src/debug/DebugApp.tsx
@@ -2,14 +2,14 @@ import { useState, useEffect, useCallback, CSSProperties } from 'react'
 
 import { Game, CommandPacket, IdentificationPacket, UpdatePacket, UnitId, Position } from '@bananu7-rts/server/src/types'
 import { Multiplayer, MatchControl, SpectatorControl } from '../Multiplayer';
-import { Board, UnitState } from '@bananu7-rts/server/src/types'
+import { Board, Unit } from '@bananu7-rts/server/src/types'
 import { MatchList } from '../components/MatchList';
 
 const multiplayer = new Multiplayer("debug_user");
 
 type Props = {
     board: Board,
-    units: UnitState[],
+    units: Unit[],
 }
 export function DebugMap(props: Props) {
     const style : CSSProperties = {
@@ -68,7 +68,7 @@ export default function DebugApp() {
     const [serverState, setServerState] = useState<Game | null>(null);
     const refresh = () => {
         if (controller && controller instanceof MatchControl) {
-            controller.getMatchState()
+            controller.debugGetMatchState()
             .then(s => setServerState(s));
         }
     };

--- a/packages/client/src/game/SelectedAction.tsx
+++ b/packages/client/src/game/SelectedAction.tsx
@@ -1,6 +1,0 @@
-
-export type SelectedAction = 
-  { action: 'Move' }
-| { action: 'Attack' }
-| { action: 'Build', building: string }
-| { action: 'Harvest' };

--- a/packages/client/src/game/SelectedCommand.tsx
+++ b/packages/client/src/game/SelectedCommand.tsx
@@ -1,0 +1,6 @@
+
+export type SelectedCommand = 
+  { command: 'Move' }
+| { command: 'Attack' }
+| { command: 'Build', building: string }
+| { command: 'Harvest' };

--- a/packages/client/src/game/UnitQuery.ts
+++ b/packages/client/src/game/UnitQuery.ts
@@ -3,7 +3,10 @@ import {
    Unit,
    ProductionFacility,
    Builder,
+   CommandBuild,
+   Building,
 } from '@bananu7-rts/server/src/types'
+import { getUnitDataByName } from '@bananu7-rts/server/src/units'
 
 import { SelectedCommand } from './SelectedCommand'
 
@@ -40,4 +43,18 @@ export function canPerformSelectedCommand(unit: Unit, command: SelectedCommand):
     case 'Build':
         return canBuild(unit, command.building);
     }
+}
+
+export function getBuildingSizeFromBuildingName(name: string): number {
+    const unitData = getUnitDataByName(name);
+
+    if (!unitData)
+        throw new Error("No unit data for the build command building");
+
+    // TODO component finding doesn't work on UnitData :(
+    const buildingComponent = unitData.find(c => c.type === 'Building') as Building;
+    if (!buildingComponent)
+        throw new Error("Build command target unit data doesn't have a Building component");
+
+    return buildingComponent.size;
 }

--- a/packages/client/src/game/UnitQuery.ts
+++ b/packages/client/src/game/UnitQuery.ts
@@ -5,7 +5,7 @@ import {
    Builder,
 } from '@bananu7-rts/server/src/types'
 
-import { SelectedAction } from './SelectedAction'
+import { SelectedCommand } from './SelectedCommand'
 
 export function canMove(unit: Unit): Boolean {
     return Boolean(unit.components.find(c => c.type === 'Mover'));
@@ -29,8 +29,8 @@ export function canBuild(unit: Unit, building: string): Boolean {
     return Boolean(builderComponent.buildingsProduced.find(bp => bp.buildingType === building));
 }
 
-export function canPerformSelectedAction(unit: Unit, action: SelectedAction): Boolean {
-    switch (action.action) {
+export function canPerformSelectedCommand(unit: Unit, command: SelectedCommand): Boolean {
+    switch (command.command) {
     case 'Move':
         return canMove(unit);
     case 'Attack':
@@ -38,25 +38,6 @@ export function canPerformSelectedAction(unit: Unit, action: SelectedAction): Bo
     case 'Harvest':
         return canHarvest(unit);
     case 'Build':
-        return canBuild(unit, action.building);
+        return canBuild(unit, command.building);
     }
-}
-
-export type UnitStatus = 'Moving'|'Attacking'|'Harvesting'|'Idle';
-
-export function getStatus(unit: Unit): UnitStatus {
-    const actionToStatus = {
-        'Attack': 'Attacking',
-        'AttackMove': 'Attacking',
-        'Follow': 'Moving',
-        'Move': 'Moving',
-        'Harvest': 'Harvesting',
-        'Produce': 'Producing',
-        'Build': 'Idle',
-        'Stop': 'Idle',
-    };
-
-    return unit.actionState.state === 'active' ?
-        (actionToStatus[unit.actionState.current.typ] as UnitStatus) :
-        'Idle';
 }

--- a/packages/client/src/game/UnitQuery.ts
+++ b/packages/client/src/game/UnitQuery.ts
@@ -1,28 +1,27 @@
 import {
    UnitId,
    Unit,
-   UnitState,
    ProductionFacility,
    Builder,
 } from '@bananu7-rts/server/src/types'
 
 import { SelectedAction } from './SelectedAction'
 
-export function canMove(unit: UnitState | Unit): Boolean {
+export function canMove(unit: Unit): Boolean {
     return Boolean(unit.components.find(c => c.type === 'Mover'));
 }
 
 // TODO: perhaps not all units can attack other units, so 
 // this might need target parameter later
-export function canAttack(unit: UnitState | Unit): Boolean {
+export function canAttack(unit: Unit): Boolean {
     return Boolean(unit.components.find(c => c.type === 'Attacker'));
 }
 
-export function canHarvest(unit: UnitState | Unit): Boolean {
+export function canHarvest(unit: Unit): Boolean {
     return Boolean(unit.components.find(c => c.type === 'Harvester'));
 }
 
-export function canBuild(unit: UnitState | Unit, building: string): Boolean {
+export function canBuild(unit: Unit, building: string): Boolean {
     const builderComponent = unit.components.find(c => c.type === 'Builder') as Builder;
     if (!builderComponent)
         return false;
@@ -30,7 +29,7 @@ export function canBuild(unit: UnitState | Unit, building: string): Boolean {
     return Boolean(builderComponent.buildingsProduced.find(bp => bp.buildingType === building));
 }
 
-export function canPerformSelectedAction(unit: UnitState | Unit, action: SelectedAction): Boolean {
+export function canPerformSelectedAction(unit: Unit, action: SelectedAction): Boolean {
     switch (action.action) {
     case 'Move':
         return canMove(unit);
@@ -41,4 +40,23 @@ export function canPerformSelectedAction(unit: UnitState | Unit, action: Selecte
     case 'Build':
         return canBuild(unit, action.building);
     }
+}
+
+export type UnitStatus = 'Moving'|'Attacking'|'Harvesting'|'Idle';
+
+export function getStatus(unit: Unit): UnitStatus {
+    const actionToStatus = {
+        'Attack': 'Attacking',
+        'AttackMove': 'Attacking',
+        'Follow': 'Moving',
+        'Move': 'Moving',
+        'Harvest': 'Harvesting',
+        'Produce': 'Producing',
+        'Build': 'Idle',
+        'Stop': 'Idle',
+    };
+
+    return unit.actionState.state === 'active' ?
+        (actionToStatus[unit.actionState.current.typ] as UnitStatus) :
+        'Idle';
 }

--- a/packages/client/src/gfx/Board3D.tsx
+++ b/packages/client/src/gfx/Board3D.tsx
@@ -9,7 +9,7 @@ import {
 
 import * as THREE from 'three';
 
-import { Board, Unit, GameMap, UnitId, Position, UnitState, TilePos } from '@bananu7-rts/server/src/types'
+import { Board, Unit, GameMap, UnitId, Position, TilePos } from '@bananu7-rts/server/src/types'
 import { SelectionCircle } from './SelectionCircle'
 import { Line3D } from './Line3D'
 import { Map3D, Box } from './Map3D'
@@ -23,7 +23,7 @@ import { SelectedAction } from '../game/SelectedAction'
 export interface Props {
     board: Board;
     playerIndex: number;
-    unitStates: UnitState[];
+    units: Unit[];
     selectedUnits: Set<UnitId>;
     selectedAction: SelectedAction | undefined;
 
@@ -39,7 +39,7 @@ export function Board3D(props: Props) {
         pointer.current.y = p.y;
     }, [pointer]);
 
-    const units = props.unitStates.map(u => {
+    const units = props.units.map(u => {
         const catalogEntryFn = UNIT_DISPLAY_CATALOG[u.kind];
         if (!catalogEntryFn)
             throw new Error("No display catalog entry for unit" + u.kind);
@@ -78,7 +78,7 @@ export function Board3D(props: Props) {
             return p.x >= x1 && p.x <= x2 && p.y >= y1 && p.y <= y2;
         }
 
-        const selection = props.unitStates
+        const selection = props.units
             .filter(u => isInBox(u.position, box))
             .filter(u => u.owner === props.playerIndex)
             .map(u => u.id);

--- a/packages/client/src/gfx/Board3D.tsx
+++ b/packages/client/src/gfx/Board3D.tsx
@@ -10,7 +10,6 @@ import {
 import * as THREE from 'three';
 
 import { Board, Unit, GameMap, UnitId, Position, TilePos, Building } from '@bananu7-rts/server/src/types'
-import { getUnitDataByName } from '@bananu7-rts/server/src/units'
 import { SelectionCircle } from './SelectionCircle'
 import { Line3D } from './Line3D'
 import { Map3D, Box } from './Map3D'
@@ -20,6 +19,7 @@ import { BuildPreview } from './BuildPreview'
 import { UNIT_DISPLAY_CATALOG, BuildingDisplayEntry } from './UnitDisplayCatalog'
 
 import { SelectedCommand } from '../game/SelectedCommand'
+import { getBuildingSizeFromBuildingName } from '../game/UnitQuery'
 
 export interface Props {
     board: Board;
@@ -90,20 +90,11 @@ export function Board3D(props: Props) {
     const createBuildPreview = useCallback(() => {
         if (!props.selectedCommand)
             return;
+
         if (props.selectedCommand.command !== 'Build')
             return;
 
-        const unitData = getUnitDataByName(props.selectedCommand.building);
-
-        if (!unitData)
-            throw new Error("No unit data for the build command building");
-
-        // TODO component finding doesn't work on UnitData :(
-        const buildingComponent = unitData.find(c => c.type === 'Building') as Building;
-        if (!buildingComponent)
-            throw new Error("Build command target unit data doesn't have a Building component");
-
-        const buildingSize = buildingComponent.size;
+        const buildingSize = getBuildingSizeFromBuildingName(props.selectedCommand.building);
 
         return (<BuildPreview
             buildingSize={buildingSize}

--- a/packages/client/src/gfx/Board3D.tsx
+++ b/packages/client/src/gfx/Board3D.tsx
@@ -19,14 +19,14 @@ import { Building3D } from './Building3D'
 import { BuildPreview } from './BuildPreview'
 import { UNIT_DISPLAY_CATALOG, BuildingDisplayEntry } from './UnitDisplayCatalog'
 
-import { SelectedAction } from '../game/SelectedAction'
+import { SelectedCommand } from '../game/SelectedCommand'
 
 export interface Props {
     board: Board;
     playerIndex: number;
     units: Unit[];
     selectedUnits: Set<UnitId>;
-    selectedAction: SelectedAction | undefined;
+    selectedCommand: SelectedCommand | undefined;
 
     select: (ids: Set<UnitId>, shift: boolean) => void;
     mapClick: (originalEvent: ThreeEvent<MouseEvent>, p: Position, button: number, shift: boolean) => void;
@@ -68,7 +68,7 @@ export function Board3D(props: Props) {
 
     const selectInBox = (box: Box, shift: boolean) => {
         // TODO - this is a hotfix; Board shouldn't make those decisions...
-        if (props.selectedAction)
+        if (props.selectedCommand)
             return;
 
         function isInBox(p: Position, b: Box) {
@@ -88,20 +88,20 @@ export function Board3D(props: Props) {
     };
 
     const createBuildPreview = useCallback(() => {
-        if (!props.selectedAction)
+        if (!props.selectedCommand)
             return;
-        if (props.selectedAction.action !== 'Build')
+        if (props.selectedCommand.command !== 'Build')
             return;
 
-        const unitData = getUnitDataByName(props.selectedAction.building);
+        const unitData = getUnitDataByName(props.selectedCommand.building);
 
         if (!unitData)
-            throw new Error("No unit data for the build action building");
+            throw new Error("No unit data for the build command building");
 
         // TODO component finding doesn't work on UnitData :(
         const buildingComponent = unitData.find(c => c.type === 'Building') as Building;
         if (!buildingComponent)
-            throw new Error("Build action target unit data doesn't have a Building component");
+            throw new Error("Build command target unit data doesn't have a Building component");
 
         const buildingSize = buildingComponent.size;
 
@@ -111,9 +111,9 @@ export function Board3D(props: Props) {
             map={props.board.map}
             units={props.units} // to check viability
         />);
-    }, [props.selectedAction]);
+    }, [props.selectedCommand]);
 
-    const buildPreview = useMemo(() => createBuildPreview(), [props.selectedAction]);
+    const buildPreview = useMemo(() => createBuildPreview(), [props.selectedCommand]);
 
     return (
         <group name="board">

--- a/packages/client/src/gfx/Board3D.tsx
+++ b/packages/client/src/gfx/Board3D.tsx
@@ -98,7 +98,12 @@ export function Board3D(props: Props) {
             {
                 props.selectedAction &&
                 props.selectedAction.action === 'Build' &&
-                <BuildPreview building={props.selectedAction.building} position={pointer} map={props.board.map}/>
+                <BuildPreview
+                    building={props.selectedAction.building}
+                    position={pointer}
+                    map={props.board.map}
+                    units={props.units} // to check viability
+                />
             }
         </group>
     );

--- a/packages/client/src/gfx/BuildPreview.tsx
+++ b/packages/client/src/gfx/BuildPreview.tsx
@@ -42,7 +42,7 @@ export function BuildPreview(props: BuildPreviewProps) {
             return;
 
         // TODO: building size
-        const emptyForBuilding = mapEmptyForBuilding(props.map, 6, gridPos);
+        const emptyForBuilding = mapEmptyForBuilding(props.map, {size: 6, type: 'Building'}, gridPos);
 
         const blobColor = emptyForBuilding ? DIM_GREEN : DIM_RED;
         const wireColor = emptyForBuilding ? BRIGHT_GREEN : BRIGHT_RED;

--- a/packages/client/src/gfx/BuildPreview.tsx
+++ b/packages/client/src/gfx/BuildPreview.tsx
@@ -1,7 +1,7 @@
 import { useRef, RefObject } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Board, Unit, GameMap, UnitId, Position, TilePos } from '@bananu7-rts/server/src/types'
-import { mapEmptyForBuilding } from '@bananu7-rts/server/src/shared'
+import { isBuildPlacementOk } from '@bananu7-rts/server/src/shared'
 import { clampToGrid } from '../game/Grid'
 
 const BRIGHT_GREEN = 0x00ff00;
@@ -13,6 +13,7 @@ type BuildPreviewProps = {
     position: RefObject<Position>;
     building: string;
     map: GameMap;
+    units: Unit[];
 }
 export function BuildPreview(props: BuildPreviewProps) {
     const unitSize = 6;
@@ -42,7 +43,7 @@ export function BuildPreview(props: BuildPreviewProps) {
             return;
 
         // TODO: building size
-        const emptyForBuilding = mapEmptyForBuilding(props.map, {size: 6, type: 'Building'}, gridPos);
+        const emptyForBuilding = isBuildPlacementOk(props.map, props.units, {size: 6, type: 'Building'}, gridPos);
 
         const blobColor = emptyForBuilding ? DIM_GREEN : DIM_RED;
         const wireColor = emptyForBuilding ? BRIGHT_GREEN : BRIGHT_RED;

--- a/packages/client/src/gfx/BuildPreview.tsx
+++ b/packages/client/src/gfx/BuildPreview.tsx
@@ -11,16 +11,17 @@ const DIM_RED = 0xcc3333;
 
 type BuildPreviewProps = {
     position: RefObject<Position>;
-    building: string;
+    // buildingDisplayEntry: BuildingDisplayEntry; // TODO visual preview
+    buildingSize: number; // gameplay value for checks
     map: GameMap;
     units: Unit[];
 }
 export function BuildPreview(props: BuildPreviewProps) {
-    const unitSize = 6;
-
     if (!props.position.current) {
         return <></>;
     }
+
+    const buildingSize = props.buildingSize;
 
     const ref = useRef<THREE.Group>(null);
     const blobMatRef = useRef<THREE.MeshBasicMaterial>(null);
@@ -36,14 +37,14 @@ export function BuildPreview(props: BuildPreviewProps) {
         const gridPos = clampToGrid(props.position.current);
 
         // TODO likely needs +3 because ref point for boxgeom is in the middle, make it respect real building size
-        ref.current.position.x = gridPos.x + 3;
-        ref.current.position.z = gridPos.y + 3;
+        ref.current.position.x = gridPos.x + buildingSize/2;
+        ref.current.position.z = gridPos.y + buildingSize/2;
 
         if (!blobMatRef.current || !wireMatRef.current)
             return;
 
         // TODO: building size
-        const emptyForBuilding = isBuildPlacementOk(props.map, props.units, {size: 6, type: 'Building'}, gridPos);
+        const emptyForBuilding = isBuildPlacementOk(props.map, props.units, {size: buildingSize, type: 'Building'}, gridPos);
 
         const blobColor = emptyForBuilding ? DIM_GREEN : DIM_RED;
         const wireColor = emptyForBuilding ? BRIGHT_GREEN : BRIGHT_RED;
@@ -55,15 +56,15 @@ export function BuildPreview(props: BuildPreviewProps) {
     return (
         <group ref={ref} position={[-100, 2, -100]}>
             <mesh>
-                <boxGeometry args={[unitSize, 2, unitSize]} />
+                <boxGeometry args={[buildingSize, 2, buildingSize]} />
                 <meshBasicMaterial ref={blobMatRef} transparent={true} opacity={0.5} />
             </mesh>
             <mesh>
-                <boxGeometry args={[unitSize, 2, unitSize]} />
+                <boxGeometry args={[buildingSize, 2, buildingSize]} />
                 <meshBasicMaterial ref={wireMatRef} wireframe={true}/>
             </mesh>
             <group position={[0, -1, 0]}>
-                <gridHelper args={[14, 7]} />
+                <gridHelper args={[buildingSize + 8, (buildingSize + 8)/2]} />
             </group>
         </group>
     );

--- a/packages/client/src/gfx/BuildPreview.tsx
+++ b/packages/client/src/gfx/BuildPreview.tsx
@@ -1,6 +1,6 @@
 import { useRef, RefObject } from 'react'
 import { useFrame } from '@react-three/fiber'
-import { Board, Unit, GameMap, UnitId, Position, UnitState, TilePos } from '@bananu7-rts/server/src/types'
+import { Board, Unit, GameMap, UnitId, Position, TilePos } from '@bananu7-rts/server/src/types'
 import { mapEmptyForBuilding } from '@bananu7-rts/server/src/shared'
 import { clampToGrid } from '../game/Grid'
 

--- a/packages/client/src/gfx/Building3D.tsx
+++ b/packages/client/src/gfx/Building3D.tsx
@@ -69,7 +69,6 @@ export function Building3D(props: Building3DProps) {
 
     // TODO animate buildings when they're producing
     const action = props.unit.state.action;
-    const animate = action === 'Producing';
 
     return (
         <group>
@@ -92,7 +91,7 @@ export function Building3D(props: Building3DProps) {
                     />
                 </group>
 
-                <FileModel path={modelPath} accentColor={color} animate={animate}/>
+                <FileModel path={modelPath} accentColor={color} animate={action}/>
             </group>
         </group>
     );

--- a/packages/client/src/gfx/Building3D.tsx
+++ b/packages/client/src/gfx/Building3D.tsx
@@ -9,13 +9,14 @@ import {
 
 import * as THREE from 'three';
 
-import { Board, Unit, GameMap, UnitId, Position, UnitState } from '@bananu7-rts/server/src/types'
+import { Board, Unit, GameMap, UnitId, Position } from '@bananu7-rts/server/src/types'
 import { SelectionCircle } from './SelectionCircle'
 import { Line3D } from './Line3D'
 import { Map3D, Box } from './Map3D'
 import { ThreeCache } from './ThreeCache'
 import { FileModel } from './FileModel'
 import { BuildingDisplayEntry } from './UnitDisplayCatalog'
+import { getStatus } from '../game/UnitQuery'
 
 const cache = new ThreeCache();
 
@@ -27,7 +28,7 @@ const invisibleMaterial = new THREE.MeshBasicMaterial({
 });
 
 type Building3DProps = {
-    unit: UnitState,
+    unit: Unit,
     selected: boolean,
     displayEntry: BuildingDisplayEntry,
     click?: (originalEvent: ThreeEvent<MouseEvent>, id: UnitId, button: number, shift: boolean) => void,
@@ -68,7 +69,8 @@ export function Building3D(props: Building3DProps) {
     }, []);
 
     // TODO animate buildings when they're producing
-    const animate = props.unit.status === 'Moving';
+    const status = getStatus(props.unit);
+    const animate = status === 'Moving';
 
     return (
         <group>

--- a/packages/client/src/gfx/Building3D.tsx
+++ b/packages/client/src/gfx/Building3D.tsx
@@ -16,7 +16,6 @@ import { Map3D, Box } from './Map3D'
 import { ThreeCache } from './ThreeCache'
 import { FileModel } from './FileModel'
 import { BuildingDisplayEntry } from './UnitDisplayCatalog'
-import { getStatus } from '../game/UnitQuery'
 
 const cache = new ThreeCache();
 
@@ -69,8 +68,8 @@ export function Building3D(props: Building3DProps) {
     }, []);
 
     // TODO animate buildings when they're producing
-    const status = getStatus(props.unit);
-    const animate = status === 'Moving';
+    const action = props.unit.state.action;
+    const animate = action === 'Producing';
 
     return (
         <group>

--- a/packages/client/src/gfx/FileModel.tsx
+++ b/packages/client/src/gfx/FileModel.tsx
@@ -57,6 +57,10 @@ function FileModel_(props: FileModelProps) {
             const harvestAnimation = gltf.animations.find(a => a.name === "Harvest");
             if (harvestAnimation)
                 animations['Harvesting'] = harvestAnimation;
+
+            const attackAnimation = gltf.animations.find(a => a.name === "Attack");
+            if (attackAnimation)
+                animations['Attacking'] = attackAnimation;
         }
 
         if (props.animate) {

--- a/packages/client/src/gfx/Map3D.tsx
+++ b/packages/client/src/gfx/Map3D.tsx
@@ -8,7 +8,7 @@ import {
 
 import * as THREE from 'three';
 
-import { Board, Unit, GameMap, UnitId, Position, UnitState } from '@bananu7-rts/server/src/types'
+import { Board, Unit, GameMap, UnitId, Position } from '@bananu7-rts/server/src/types'
 
 import { SelectionBox } from './SelectionBox'
 

--- a/packages/client/src/gfx/Unit3D.tsx
+++ b/packages/client/src/gfx/Unit3D.tsx
@@ -9,14 +9,13 @@ import {
 
 import * as THREE from 'three';
 
-import { Board, Unit, GameMap, UnitId, Position } from '@bananu7-rts/server/src/types'
+import { Board, Unit, GameMap, UnitId, Position, UnitAction } from '@bananu7-rts/server/src/types'
 import { SelectionCircle } from './SelectionCircle'
 import { Line3D } from './Line3D'
 import { Map3D, Box } from './Map3D'
 import { ThreeCache } from './ThreeCache'
 import { FileModel } from './FileModel'
 import { UnitDisplayEntry } from './UnitDisplayCatalog'
-import { getStatus, UnitStatus } from '../game/UnitQuery'
 import { Horizon } from '../debug/Horizon'
 
 // TODO make this settable more easily
@@ -37,14 +36,14 @@ const invisibleMaterial = new THREE.MeshBasicMaterial({
 });
 
 const coneGeometry = new THREE.ConeGeometry(0.5, 2, 8);
-function ConeIndicator(props: {status: UnitStatus, smoothing: boolean}) {
+function ConeIndicator(props: {action: UnitAction, smoothing: boolean}) {
     // TODO - this will be replaced with animations etc
     let indicatorColor = 0xeeeeee;
-    if (status === 'Moving')
+    if (props.action === 'Moving')
         indicatorColor = 0x55ff55;
-    else if (status === 'Attacking')
+    else if (props.action === 'Attacking')
         indicatorColor = 0xff5555;
-    else if (status === 'Harvesting')
+    else if (props.action === 'Harvesting')
         indicatorColor = 0x5555ff;
     // indicate discrepancy between server and us
     else if (props.smoothing)
@@ -155,14 +154,14 @@ export function Unit3D(props: Unit3DProps) {
         return new THREE.Vector3(a.x, 1, a.y);
     });
 
-    const status = getStatus(props.unit);
-    const animate = status === 'Moving';
+    const action = props.unit.state.action;
+    const animate = action === 'Moving';
 
     return (
         <group>
             { debugFlags.showPaths && 
                 props.selected && debugPath &&
-                <Line3D points={[new THREE.Vector3(props.unit.position.x, 1, props.unit.position.y), ...debugPath]} />
+                <Line3D points={[new THREE.Vector3(props.unit.position.x, 1.1, props.unit.position.y), ...debugPath]} />
             }
             <group
                 ref={unitGroupRef}
@@ -191,7 +190,7 @@ export function Unit3D(props: Unit3DProps) {
                     />
 
                     { debugFlags.showCones &&
-                        <ConeIndicator status={status} smoothing={smoothingVelocity.x > 0.01 || smoothingVelocity.y > 0.01} />
+                        <ConeIndicator action={action} smoothing={smoothingVelocity.x > 0.01 || smoothingVelocity.y > 0.01} />
                     }
 
                     <FileModel path={modelPath} accentColor={color} animate={animate}/>

--- a/packages/client/src/gfx/Unit3D.tsx
+++ b/packages/client/src/gfx/Unit3D.tsx
@@ -155,7 +155,6 @@ export function Unit3D(props: Unit3DProps) {
     });
 
     const action = props.unit.state.action;
-    const animate = action === 'Moving';
 
     return (
         <group>
@@ -193,7 +192,7 @@ export function Unit3D(props: Unit3DProps) {
                         <ConeIndicator action={action} smoothing={smoothingVelocity.x > 0.01 || smoothingVelocity.y > 0.01} />
                     }
 
-                    <FileModel path={modelPath} accentColor={color} animate={animate}/>
+                    <FileModel path={modelPath} accentColor={color} animate={action}/>
                 </group>
             </group>
         </group>

--- a/packages/client/src/gfx/Unit3D.tsx
+++ b/packages/client/src/gfx/Unit3D.tsx
@@ -9,14 +9,14 @@ import {
 
 import * as THREE from 'three';
 
-import { Board, Unit, GameMap, UnitId, Position, UnitState } from '@bananu7-rts/server/src/types'
+import { Board, Unit, GameMap, UnitId, Position } from '@bananu7-rts/server/src/types'
 import { SelectionCircle } from './SelectionCircle'
 import { Line3D } from './Line3D'
 import { Map3D, Box } from './Map3D'
 import { ThreeCache } from './ThreeCache'
 import { FileModel } from './FileModel'
 import { UnitDisplayEntry } from './UnitDisplayCatalog'
-
+import { getStatus, UnitStatus } from '../game/UnitQuery'
 import { Horizon } from '../debug/Horizon'
 
 // TODO make this settable more easily
@@ -37,14 +37,14 @@ const invisibleMaterial = new THREE.MeshBasicMaterial({
 });
 
 const coneGeometry = new THREE.ConeGeometry(0.5, 2, 8);
-function ConeIndicator(props: {unit: UnitState, smoothing: boolean}) {
+function ConeIndicator(props: {status: UnitStatus, smoothing: boolean}) {
     // TODO - this will be replaced with animations etc
     let indicatorColor = 0xeeeeee;
-    if (props.unit.status === 'Moving')
+    if (status === 'Moving')
         indicatorColor = 0x55ff55;
-    else if (props.unit.status === 'Attacking')
+    else if (status === 'Attacking')
         indicatorColor = 0xff5555;
-    else if (props.unit.status === 'Harvesting')
+    else if (status === 'Harvesting')
         indicatorColor = 0x5555ff;
     // indicate discrepancy between server and us
     else if (props.smoothing)
@@ -61,7 +61,7 @@ function ConeIndicator(props: {unit: UnitState, smoothing: boolean}) {
 }
 
 type Unit3DProps = {
-    unit: UnitState,
+    unit: Unit,
     displayEntry: UnitDisplayEntry,
     selected: boolean,
     click?: (originalEvent: ThreeEvent<MouseEvent>, id: UnitId, button: number, shift: boolean) => void,
@@ -155,7 +155,8 @@ export function Unit3D(props: Unit3DProps) {
         return new THREE.Vector3(a.x, 1, a.y);
     });
 
-    const animate = props.unit.status === 'Moving';
+    const status = getStatus(props.unit);
+    const animate = status === 'Moving';
 
     return (
         <group>
@@ -190,7 +191,7 @@ export function Unit3D(props: Unit3DProps) {
                     />
 
                     { debugFlags.showCones &&
-                        <ConeIndicator unit={props.unit} smoothing={smoothingVelocity.x > 0.01 || smoothingVelocity.y > 0.01} />
+                        <ConeIndicator status={status} smoothing={smoothingVelocity.x > 0.01 || smoothingVelocity.y > 0.01} />
                     }
 
                     <FileModel path={modelPath} accentColor={color} animate={animate}/>

--- a/packages/client/src/gfx/UnitDisplayCatalog.ts
+++ b/packages/client/src/gfx/UnitDisplayCatalog.ts
@@ -39,5 +39,10 @@ export const UNIT_DISPLAY_CATALOG : UnitDisplayCatalog = {
         isBuilding: false,
         modelPath: 'catapult.glb',
         selectorSize: 2.5,
-    })
+    }),
+    'Tower': () => ({
+        isBuilding: true,
+        modelPath: 'tower.glb',
+        selectorSize: 4,
+    }),
 };

--- a/packages/server/src/components.ts
+++ b/packages/server/src/components.ts
@@ -1,0 +1,36 @@
+import { 
+    Unit,
+    Hp, Mover, Attacker, Harvester, ProductionFacility, Builder, Vision, Building
+} from './types'
+
+export const getHpComponent = (unit: Unit) => {
+    return unit.components.find(c => c.type === 'Hp') as Hp;
+}
+
+export const getMoveComponent = (unit: Unit) => {
+    return unit.components.find(c => c.type === 'Mover') as Mover;
+}
+
+export const getAttackerComponent = (unit: Unit) => {
+    return unit.components.find(c => c.type === 'Attacker') as Attacker;
+}
+
+export const getHarvesterComponent = (unit: Unit) => {
+    return unit.components.find(c => c.type === 'Harvester') as Harvester;
+}
+
+export const getProducerComponent = (unit: Unit) => {
+    return unit.components.find(c => c.type === 'ProductionFacility') as ProductionFacility;
+}
+
+export const getBuilderComponent = (unit: Unit) => {
+    return unit.components.find(c => c.type === 'Builder') as Builder;
+}
+
+export const getVisionComponent = (unit: Unit) => {
+    return unit.components.find(c => c.type === 'Vision') as Vision;
+}
+
+export const getBuildingComponent = (unit: Unit) => {
+    return unit.components.find(c => c.type === 'Building') as Building;
+};

--- a/packages/server/src/game.ts
+++ b/packages/server/src/game.ts
@@ -379,19 +379,23 @@ function updateUnit(dt: Milliseconds, g: Game, unit: Unit, presence: PresenceMap
             return true;
         }
 
-        unit.debug ??= {};
-        unit.debug.pathToNext = unit.pathToNext;
-
-        let distanceLeft = distancePerTick;
-
         let target = unit.pathToNext[0];
         let targetDist = V.distance(target, unit.position);
 
         // Skip ONE path node if it's in reach of this ticks' movement
-        // TODO we'll see if it helps with jagged turns
         if (targetDist < distancePerTick) {
+            // if that node is the last, move to it ending navigation
+            if (unit.pathToNext.length === 1) {
+                V.vecSet(unit.velocity, V.difference(target, unit.position));
+                return true;
+            }
+
+            // otherwise just remove it for the next iteration
             unit.pathToNext.shift();
         }
+
+        unit.debug ??= {};
+        unit.debug.pathToNext = unit.pathToNext;
 
         // this is the direction the unit is facing regardless of actual movement
         // TODO probably should turn when bypassing obstacles maybe?

--- a/packages/server/src/game.ts
+++ b/packages/server/src/game.ts
@@ -1,7 +1,7 @@
 import {
     Milliseconds, Position,
     Board,
-    GameMap, Game, PlayerIndex, Unit, UnitId, Component, CommandPacket, UpdatePacket, PresenceMap, TilePos, UnitState, 
+    GameMap, Game, PlayerIndex, Unit, UnitId, Component, CommandPacket, UpdatePacket, PresenceMap, TilePos, 
     Hp, Mover, Attacker, Harvester, ProductionFacility, Builder, Vision, Building,
     Action, ActionFollow, ActionAttack, ActionMove,
     PlayerState,
@@ -230,29 +230,14 @@ export function tick(dt: Milliseconds, g: Game): UpdatePacket[] {
         updateUnits(dt, g);
     }
 
-    const unitUpdates: UnitState[] = g.units
+    const unitUpdates: Unit[] = g.units
         .map(u => {
             // TODO pull actual action that's done right at the moment
             // (including cooldowns etc)
             // maybe this should happen client-side actually?
-            const actionToStatus = {
-                'Attack': 'Attacking',
-                'AttackMove': 'Attacking',
-                'Follow': 'Moving',
-                'Move': 'Moving',
-                'Harvest': 'Harvesting',
-                'Produce': 'Producing',
-                'Build': 'Idle',
-                'Stop': 'Idle',
-            }
-            type US = 'Moving'|'Attacking'|'Harvesting'|'Idle';
-            const status: (US) = u.actionState.state === 'active' ?
-                (actionToStatus[u.actionState.current.typ] as US) :
-                'Idle';
-
             return {
                 id: u.id,
-                status,
+                actionState: u.actionState,
                 position: u.position,
                 direction: u.direction,
                 velocity: u.velocity,

--- a/packages/server/src/game.ts
+++ b/packages/server/src/game.ts
@@ -496,6 +496,7 @@ function updateUnit(dt: Milliseconds, g: Game, unit: Unit, presence: PresenceMap
             // SC in that case just cancels the attack command - TODO decide
             moveTowards(target.position, ac.range);
         } else {
+            unit.state.action = 'Attacking';
             unit.direction = V.angleFromTo(unit.position, target.position);
             attemptDamage(ac, target);
         }

--- a/packages/server/src/game.ts
+++ b/packages/server/src/game.ts
@@ -779,11 +779,16 @@ function updateUnit(dt: Milliseconds, g: Game, unit: Unit, presence: PresenceMap
                 if (!isBuildPlacementOk(g.board.map, g.units, buildingComponent, cmd.position))
                     throw "[game] Unit ordered to build but some tiles are obscured";
 
-                const BUILDING_DISTANCE = 2;
-                switch(moveTowards(cmd.position, BUILDING_DISTANCE)) {
+                // the buildings are pretty large, so the worker should go towards the center
+                const buildingSize = buildingComponent.size;
+                const middleOfTheBuilding = V.sumScalar(cmd.position, buildingSize/2);
+                // and is able to build once they reach the perimeter
+                const buildingDistance = buildingComponent.size / 2 + 1;
+
+                switch(moveTowards(middleOfTheBuilding, buildingDistance)) {
                 case 'Unreachable':
-                    clearCurrentCommand();
-                    break;
+                    throw "[game] Unit ordered to build but location is unreachable.";
+
                 case 'ReachedTarget':
                     owner.resources -= buildCapability.buildCost;
                     // TODO - this should take time

--- a/packages/server/src/game.ts
+++ b/packages/server/src/game.ts
@@ -12,7 +12,7 @@ import { pathFind } from './pathfinding.js'
 import { checkMovePossibility } from './movement.js'
 import { createUnit, createStartingUnits, getUnitDataByName, UnitData } from './units.js'
 import { notEmpty } from './tsutil.js'
-import { mapEmptyForBuilding, tilesTakenByBuilding } from './shared.js'
+import { isBuildPlacementOk, mapEmptyForBuilding, tilesTakenByBuilding } from './shared.js'
 import { getHpComponent, getMoveComponent, getAttackerComponent, getHarvesterComponent, getProducerComponent, getBuilderComponent, getVisionComponent, getBuildingComponent } from './components.js'
 
 // general accuracy when the unit assumes it has reached
@@ -761,7 +761,7 @@ function updateUnit(dt: Milliseconds, g: Game, unit: Unit, presence: PresenceMap
                 if (!buildingComponent)
                     throw "[game] Unit ordered to build something that's not a building: " + cmd.building;
 
-                if (!mapEmptyForBuilding(g.board.map, buildingComponent, cmd.position))
+                if (!isBuildPlacementOk(g.board.map, g.units, buildingComponent, cmd.position))
                     throw "[game] Unit ordered to build but some tiles are obscured";
 
                 const BUILDING_DISTANCE = 2;

--- a/packages/server/src/game.ts
+++ b/packages/server/src/game.ts
@@ -78,6 +78,7 @@ function commandOne(shift: boolean, command: Command, unit: Unit, playerIndex: n
         else {
             unit.state.current = command;
             unit.state.rest = [];
+            delete unit.pathToNext;
         }
     }
 }

--- a/packages/server/src/game.ts
+++ b/packages/server/src/game.ts
@@ -13,6 +13,7 @@ import { checkMovePossibility } from './movement.js'
 import { createUnit, createStartingUnits, getUnitDataByName, UnitData } from './units.js'
 import { notEmpty } from './tsutil.js'
 import { mapEmptyForBuilding, tilesTakenByBuilding } from './shared.js'
+import { getHpComponent, getMoveComponent, getAttackerComponent, getHarvesterComponent, getProducerComponent, getBuilderComponent, getVisionComponent, getBuildingComponent } from './components.js'
 
 // general accuracy when the unit assumes it has reached
 // its destination
@@ -273,38 +274,6 @@ export function tick(dt: Milliseconds, g: Game): UpdatePacket[] {
     });
 }
 
-const getHpComponent = (unit: Unit): Hp => {
-    return unit.components.find(c => c.type === 'Hp') as Hp;
-}
-
-const getMoveComponent = (unit: Unit): Mover => {
-    return unit.components.find(c => c.type === 'Mover') as Mover;
-}
-
-const getAttackerComponent = (unit: Unit) => {
-    return unit.components.find(c => c.type === 'Attacker') as Attacker;
-}
-
-const getHarvesterComponent = (unit: Unit) => {
-    return unit.components.find(c => c.type === 'Harvester') as Harvester;
-}
-
-const getProducerComponent = (unit: Unit) => {
-    return unit.components.find(c => c.type === 'ProductionFacility') as ProductionFacility;
-}
-
-const getBuilderComponent = (unit: Unit) => {
-    return unit.components.find(c => c.type === 'Builder') as Builder;
-}
-
-const getVisionComponent = (unit: Unit) => {
-    return unit.components.find(c => c.type === 'Vision') as Vision;
-}
-
-const getBuildingComponent = (unit: Unit) => {
-    return unit.components.find(c => c.type === 'Building') as Building;
-};
-
 function buildPresenceMap(units: Unit[], board: Board): PresenceMap {
     const presence: PresenceMap = new Map();
     const explode = (p: Position | TilePos) => Math.floor(p.x) + Math.floor(p.y) * board.map.w;
@@ -318,7 +287,7 @@ function buildPresenceMap(units: Unit[], board: Board): PresenceMap {
     for (const u of units) {
         const bc = getBuildingComponent(u);
         if (bc) {
-            const tilesToMark = tilesTakenByBuilding(bc.size, u.position);
+            const tilesToMark = tilesTakenByBuilding(bc, u.position);
             tilesToMark.forEach(t => mark(u, t));
         } else {
             mark(u, u.position);
@@ -807,7 +776,7 @@ function updateUnit(dt: Milliseconds, g: Game, unit: Unit, presence: PresenceMap
                 if (!buildingComponent)
                     throw "[game] Unit ordered to build something that's not a building: " + cmd.building;
 
-                if (!mapEmptyForBuilding(g.board.map, buildingComponent.size, cmd.position))
+                if (!mapEmptyForBuilding(g.board.map, buildingComponent, cmd.position))
                     throw "[game] Unit ordered to build but some tiles are obscured";
 
                 const BUILDING_DISTANCE = 2;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,7 +5,7 @@ import cors from 'cors'
 import bodyParser from 'body-parser'
 
 import {newGame, startGame, tick, command} from './game.js';
-import {Game, MatchInfo, IdentificationPacket, CommandPacket, UpdatePacket, UserId } from './types.js';
+import {Game, MatchInfo, IdentificationPacket, CommandPacket, UpdatePacket, UserId, MatchId, MatchMetadata } from './types.js';
 import {getMap} from './map.js';
 import {readFileSync} from 'fs';
 
@@ -21,6 +21,7 @@ type PlayerEntry = {
     index: number,
     user: UserId,
     channel?: ServerChannel,
+    color: number,
 }
 
 type SpectatorEntry = {
@@ -30,9 +31,21 @@ type SpectatorEntry = {
 
 type Match = {
     game: Game,
-    matchId: string,
+    matchId: MatchId,
     players: PlayerEntry[],
     spectators: SpectatorEntry[],
+}
+
+function getMatchMetadata(m: Match): MatchMetadata {
+    return {
+        matchId: m.matchId,
+        board: m.game.board,
+        players: m.players.map(p => ({
+            index: p.index,
+            userId: p.user,
+            color: p.color
+        })),
+    };
 }
 
 const app = express()
@@ -60,7 +73,23 @@ app.get('/version', (req, res) => {
     res.send(version);
 });
 
-app.get('/getMatchState', (req, res) => {
+app.get('/getMatchMetadata', (req, res) => {
+    const match = matches.find(m => m.matchId === req.query.matchId);
+    if (match) {
+        res.send(JSON.stringify(getMatchMetadata(match)));
+    }
+    else {
+        res.sendStatus(404);
+    }
+});
+
+// TODO debug apis should require a secret
+app.get('/debugGetPath', (req, res) => {
+    // TODO: pull the pathfinding path of a given unit
+    res.sendStatus(500);
+});
+
+app.get('/debugGetMatchState', (req, res) => {
     const match = matches.find(m => m.matchId === req.query.matchId);
     if (match) {
         res.send(JSON.stringify(match.game));
@@ -68,11 +97,6 @@ app.get('/getMatchState', (req, res) => {
     else {
         res.sendStatus(404);
     }
-});
-
-app.get('/debugGetPath', (req, res) => {
-    // TODO: pull the pathfinding path of a given unit
-    res.sendStatus(500);
 });
 
 let lastMatchId = 0;
@@ -151,7 +175,8 @@ app.post('/join', async (req, res) => {
                 break;
         }
         console.log(`[index] Adding user ${userId} as player number ${index} in match ${matchId}`);
-        match.players.push({ user: userId, index });
+        // TODO - assign colors        
+        match.players.push({ user: userId, index, color: 0 });
 
         res.send(JSON.stringify({
             playerIndex: index

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -125,6 +125,7 @@ app.post('/create', async (req, res) => {
         });
 
         match.spectators.forEach((s, i) => 
+            // TODO spectators should get a separate packet
             s.channel.emit('tick', updatePackets[0])
         );
         // io.room(matchId).emit('tick', updatePackets[0]);

--- a/packages/server/src/movement.ts
+++ b/packages/server/src/movement.ts
@@ -1,5 +1,5 @@
 import {
-    GameMap, Game, PlayerIndex, Unit, UnitId, Component, Position, TilePos, UnitState, PresenceMap,
+    GameMap, Game, PlayerIndex, Unit, UnitId, Component, Position, TilePos, PresenceMap,
     Hp, Mover, Attacker, Harvester, ProductionFacility, Builder, Vision,
     Action, ActionFollow, ActionAttack,
 } from './types';

--- a/packages/server/src/movement.ts
+++ b/packages/server/src/movement.ts
@@ -1,8 +1,9 @@
 import {
-    GameMap, Game, PlayerIndex, Unit, UnitId, Component, Position, TilePos, PresenceMap,
+    GameMap, Game, PlayerIndex, Unit, UnitId, Component, Position, TilePos, PresenceMap, BuildingMap,
     Hp, Mover, Attacker, Harvester, ProductionFacility, Builder, Vision,
     Command, CommandFollow, CommandAttack,
 } from './types';
+import { getBuildingComponent } from './components.js'
 
 import * as V from './vector.js'
 import { notEmpty } from './tsutil.js'
@@ -88,6 +89,10 @@ export function checkMovePossibility(unit: Unit, gm: GameMap, presence: Presence
     
     let separation = {x:0, y:0};
     for (const u of otherUnitsNearby) {
+        // Don't use separation force on buildings
+        if (getBuildingComponent(u))
+            continue;
+
         const MAX_LOCAL_SEPARATION_FORCE = 2;
         const SEPARATION_OVERCOMP = 1.05; // overcompensation for separation distance
 

--- a/packages/server/src/movement.ts
+++ b/packages/server/src/movement.ts
@@ -1,7 +1,7 @@
 import {
     GameMap, Game, PlayerIndex, Unit, UnitId, Component, Position, TilePos, PresenceMap,
     Hp, Mover, Attacker, Harvester, ProductionFacility, Builder, Vision,
-    Action, ActionFollow, ActionAttack,
+    Command, CommandFollow, CommandAttack,
 } from './types';
 
 import * as V from './vector.js'
@@ -14,8 +14,8 @@ export function checkMovePossibility(unit: Unit, gm: GameMap, presence: Presence
     const explode = (p: TilePos) => p.x+p.y*gm.w; 
 
     // Disable collisions for harvesting units
-    if (unit.actionState.state === 'active' &&
-        unit.actionState.current.typ === 'Harvest'
+    if (unit.state.state === 'active' &&
+        unit.state.current.typ === 'Harvest'
     ) {
         let velocity = {
             x: Math.cos(unit.direction),

--- a/packages/server/src/pathfinding.ts
+++ b/packages/server/src/pathfinding.ts
@@ -59,6 +59,18 @@ function gridPathFind(start: TilePos, b: TilePos, m: GameMap) {
 
     const explodedB = explode(b);
 
+    const isTileWithinBounds = (t: TilePos) => t.x > 0 && t.y > 0 && t.x < m.w && t.y < m.h;
+
+    // this is necessary because path lies on edges of tiles, not through the middle
+    // this check verifies the "width" of the path to be 2
+    // TODO different sizes for different units?
+    const isClearAroundTile = (t: TilePos) => (
+        m.tiles[explode(t)] === 0 &&
+        m.tiles[explode({x: t.x,   y: t.y-1})] === 0 &&
+        m.tiles[explode({x: t.x-1, y: t.y})] === 0 &&
+        m.tiles[explode({x: t.x-1, y: t.y-1})] === 0
+    );
+
     while (!q.isEmpty()) {
         const [current, v] = q.poll() as [TilePos, number]; // TODO this `as` looks like a bug in pqueue typing
 
@@ -67,8 +79,8 @@ function gridPathFind(start: TilePos, b: TilePos, m: GameMap) {
 
         const options = 
             getSurroundingPos(current)
-            .filter(e => e.x > 0 && e.y > 0 && e.x < m.w && e.y < m.h)
-            .filter(e => m.tiles[explode(e)] === 0);
+            .filter(t => isTileWithinBounds(t))
+            .filter(t => isClearAroundTile(t));
 
         for (let next of options) {
             // detect if moving diagonally

--- a/packages/server/src/shared.ts
+++ b/packages/server/src/shared.ts
@@ -1,7 +1,11 @@
-import { GameMap, TilePos, Position } from './types'
+import { Game, GameMap, TilePos, Position, Building } from './types'
+import { getBuildingComponent } from './components.js'
+import { notEmpty } from './tsutil.js'
 
-export function tilesTakenByBuilding(buildingSize: number, position: Position): TilePos[] {
+export function tilesTakenByBuilding(building: Building, position: Position): TilePos[] {
     const tiles: TilePos[] = [];
+    const buildingSize = building.size;
+
     for (let x = position.x; x < position.x + buildingSize; x += 1) {
         for (let y = position.y; y < position.y + buildingSize; y += 1) {
             tiles.push({ x, y });
@@ -10,7 +14,7 @@ export function tilesTakenByBuilding(buildingSize: number, position: Position): 
     return tiles;
 }
 
-export function mapEmptyForBuilding(gm: GameMap, buildingSize: number, position: Position): boolean {
+export function mapEmptyForBuilding(gm: GameMap, building: Building, position: Position): boolean {
     const isOnModN = (x: number, n: number) => x/n - Math.floor(x/n) === 0;
 
     // buildings can only be built on mod2 grid
@@ -19,11 +23,39 @@ export function mapEmptyForBuilding(gm: GameMap, buildingSize: number, position:
         return false;
     }
 
-    const tilesToCheck = tilesTakenByBuilding(buildingSize, position);
+    const tilesToCheck = tilesTakenByBuilding(building, position);
 
     // TODO this is getting duplicated, maybe GameMap needs better utility functions
     const explode = (p: TilePos) => p.x+p.y*gm.w;
 
     const empty = ! tilesToCheck.some(t => gm.tiles[explode(t)] !== 0);
     return empty;
+}
+
+export function isBuildPlacementOk(game: Game, building: Building, position: Position): boolean {
+    const mapEmpty = mapEmptyForBuilding(game.board.map, building, position);
+    if (!mapEmpty)
+        return false;
+
+    // TODO this should perhaps be cached?
+    const buildings = game.units.map(u => ({ pos: u.position, bc: getBuildingComponent(u)})).filter(({pos, bc}) => bc);
+    const tiles = buildings.map(({pos, bc}) => tilesTakenByBuilding(bc, pos));
+
+    // TODO this is getting duplicated, maybe GameMap needs better utility functions
+    const gm = game.board.map;
+    const explode = (p: TilePos) => p.x+p.y*gm.w;
+    const obscuredTiles = new Set();
+    tiles
+        .flat(1)
+        .map(t => explode(t))
+        .forEach(t => obscuredTiles.add(t));
+
+    const desiredTiles = tilesTakenByBuilding(building, position).map(explode);
+
+    for (const t of desiredTiles) {
+        if (obscuredTiles.has(t)) 
+            return false;
+    }
+
+    return true;
 }

--- a/packages/server/src/shared.ts
+++ b/packages/server/src/shared.ts
@@ -1,4 +1,4 @@
-import { Game, GameMap, TilePos, Position, Building } from './types'
+import { Game, GameMap, TilePos, Position, Building, Unit } from './types'
 import { getBuildingComponent } from './components.js'
 import { notEmpty } from './tsutil.js'
 
@@ -32,17 +32,16 @@ export function mapEmptyForBuilding(gm: GameMap, building: Building, position: P
     return empty;
 }
 
-export function isBuildPlacementOk(game: Game, building: Building, position: Position): boolean {
-    const mapEmpty = mapEmptyForBuilding(game.board.map, building, position);
+export function isBuildPlacementOk(gm: GameMap, units: Unit[], building: Building, position: Position): boolean {
+    const mapEmpty = mapEmptyForBuilding(gm, building, position);
     if (!mapEmpty)
         return false;
 
     // TODO this should perhaps be cached?
-    const buildings = game.units.map(u => ({ pos: u.position, bc: getBuildingComponent(u)})).filter(({pos, bc}) => bc);
+    const buildings = units.map(u => ({ pos: u.position, bc: getBuildingComponent(u)})).filter(({pos, bc}) => bc);
     const tiles = buildings.map(({pos, bc}) => tilesTakenByBuilding(bc, pos));
 
     // TODO this is getting duplicated, maybe GameMap needs better utility functions
-    const gm = game.board.map;
     const explode = (p: TilePos) => p.x+p.y*gm.w;
     const obscuredTiles = new Set();
     tiles

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -64,22 +64,8 @@ export type CommandPacket = {
 export type UpdatePacket = {
     state: GameState,
     tickNumber: number,
-    units: UnitState[],
+    units: Unit[],
     player: PlayerState,
-}
-
-export type UnitState = {
-    debug?: any;
-
-    id: number,
-    kind: string,
-    status: 'Moving'|'Attacking'|'Harvesting'|'Producing'|'Idle',
-    readonly position: Position,
-    velocity: Position, // TODO - Position to Vec2
-    direction: number,
-    owner: number,
-
-    components: Component[],
 }
 
 // Components
@@ -188,6 +174,7 @@ export type Unit = {
 
     readonly components: Component[],
 
+    // Only used on the server
     pathToNext?: TilePos[],
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -36,42 +36,42 @@ export type IdentificationPacket = {
     matchId: MatchId, 
 }
 
-export type Action = ActionMove | ActionStop | ActionFollow | ActionAttackMove | ActionAttack | ActionHarvest | ActionProduce | ActionBuild;
-export type ActionMove = {
+export type Command = CommandMove | CommandStop | CommandFollow | CommandAttackMove | CommandAttack | CommandHarvest | CommandProduce | CommandBuild;
+export type CommandMove = {
     typ: 'Move',
     target: Position,
 }
-export type ActionStop = {
+export type CommandStop = {
     typ: 'Stop'
 }
-export type ActionFollow = {
+export type CommandFollow = {
     typ: 'Follow',
     target: UnitId,
 }
-export type ActionAttackMove = {
+export type CommandAttackMove = {
     typ: 'AttackMove',
     target: Position,
 }
-export type ActionAttack = {
+export type CommandAttack = {
     typ: 'Attack',
     target: UnitId,
 }
-export type ActionHarvest = {
+export type CommandHarvest = {
     typ: 'Harvest',
     target: UnitId,
 }
-export type ActionProduce = {
+export type CommandProduce = {
     typ: 'Produce',
     unitToProduce: string,
 }
-export type ActionBuild = {
+export type CommandBuild = {
     typ: 'Build',
     building: string,
     position: Position,
 }
 
 export type CommandPacket = {
-    action: Action,
+    command: Command,
     unitIds: UnitId[],
     shift: boolean,
 }
@@ -162,25 +162,35 @@ export type TilePos = { x: number, y: number }
 export type PlayerIndex = number
 export type UserId = string
 
+
+export type UnitAction = 'Moving'|'Attacking'|'Harvesting'|'Idle'|'Producing'|'Building';
+
+// TODO this should probably be a separate variable instead
+type UnitActionState = {
+    action: UnitAction,
+    actionTime: number, // how long has the unit been performing the current action?
+}
+
 // represents a non-empty queue
 export type UnitActiveState = {
     state: 'active',
-    current: Action,
-    rest: Action[],
-}
+    current: Command,
+    rest: Command[],    
+} & UnitActionState
 
 export type UnitIdleState = {
     state: 'idle',
     idlePosition: Position,
-}
+} & UnitActionState
 
-export type ActionState = UnitIdleState | UnitActiveState;
+export type UnitState = UnitIdleState | UnitActiveState;
 
 export type Unit = {
     debug?: any;
 
     readonly id: number,
-    actionState: ActionState,
+    state: UnitState,
+
     readonly kind: string, // TODO should this be in a component
     readonly owner: PlayerIndex,
     readonly position: Position,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -242,3 +242,4 @@ export type GameState = {
 }
 
 export type PresenceMap = Map<number, Unit[]>;
+export type BuildingMap = Map<number, UnitId>;

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -9,16 +9,31 @@ export type Milliseconds = number;
 
 export type UnitId = number;
 
-// Network connectivity
+// used for MatchList
+export type MatchId = string;
+
 export type MatchInfo = {
-    matchId: string,
+    matchId: MatchId,
     playerCount: number,
     status: GameState, 
 }
 
+// constant for the entire match, used by the match controller
+export type PlayerMetadata = {
+    readonly index: PlayerIndex,
+    readonly userId: UserId,
+    readonly color: number,
+}
+
+export type MatchMetadata = {
+    readonly matchId: MatchId;
+    readonly players: PlayerMetadata[],
+    readonly board: Board,
+}
+
 export type IdentificationPacket = {
     userId: UserId,
-    matchId: string, 
+    matchId: MatchId, 
 }
 
 export type Action = ActionMove | ActionStop | ActionFollow | ActionAttackMove | ActionAttack | ActionHarvest | ActionProduce | ActionBuild;
@@ -184,7 +199,7 @@ export type PlayerState = {
 
 export type Game = {
     // uuid: UUID, TODO
-    matchId: string,
+    matchId: MatchId,
     state: GameState,
     tickNumber: number,
     players: PlayerState[],

--- a/packages/server/src/units.ts
+++ b/packages/server/src/units.ts
@@ -61,7 +61,7 @@ export function getUnitDataByName(name: string): UnitData | undefined {
 
 export const createUnit = (id: number, owner: number, kind: string, position: Position): Unit => {
     return {
-        actionState: { state: 'idle', idlePosition: { x:position.x, y:position.y}},
+        state: { state: 'idle', action: 'Idle', actionTime: 0, idlePosition: { x:position.x, y:position.y}},
         id,
         kind,
         owner,

--- a/packages/server/src/units.ts
+++ b/packages/server/src/units.ts
@@ -18,6 +18,7 @@ const UNIT_CATALOG : Catalog = {
         { type: 'Builder', buildingsProduced: [
             { buildingType: 'Base', buildTime: 5000, buildCost: 400 },
             { buildingType: 'Barracks', buildTime: 5000, buildCost: 150},
+            { buildingType: 'Tower', buildTime: 5000, buildCost: 50},
         ]},
         { type: 'Vision', range: 10 },
     ],
@@ -39,6 +40,11 @@ const UNIT_CATALOG : Catalog = {
             {unitType: 'Trooper', productionTime: 5000, productionCost: 50}
         ]},
         { type: 'Vision', range: 5 },
+    ],
+    'Tower': () => [
+        { type: 'Hp', maxHp: 300, hp: 300 },
+        { type: 'Building', size: 4 },
+        { type: 'Vision', range: 12 },
     ],
     'Trooper': () => [
         { type: 'Hp', maxHp: 50, hp: 50 },

--- a/packages/server/src/units.ts
+++ b/packages/server/src/units.ts
@@ -1,5 +1,5 @@
 import {
-    Unit, UnitId, Component, Position, UnitState,
+    Unit, UnitId, Component, Position,
 } from './types';
 
 export type UnitData = Component[];

--- a/packages/server/src/vector.ts
+++ b/packages/server/src/vector.ts
@@ -46,3 +46,28 @@ export function vecAdd(a: Position, b: Position) {
     a.x += b.x;
     a.y += b.y;
 }
+
+export function scalarMul(a: Position, b: number) {
+    a.x *= b;
+    a.y *= b;
+}
+
+export function normalize(a: Position) {
+    const m = magnitude(a);
+    a.x /= m;
+    a.y /= m;
+}
+
+type WeightedVector = {
+    v: Position,
+    e: number,
+}
+export function weightedDirectionCombine(vs: WeightedVector[]) {
+    const res = { x: 0, y: 0 };
+    for (const {v, e} of vs) {
+        res.x += v.x * e;
+        res.y += v.y * e;
+    }
+    normalize(res);
+    return res;
+}

--- a/packages/server/src/vector.ts
+++ b/packages/server/src/vector.ts
@@ -28,6 +28,10 @@ export function sum(a: Position, b: Position) {
     return {x: a.x + b.x, y: a.y + b.y };
 }
 
+export function mul(a: Position, b: number) {
+    return {x: a.x * b, y: a.y * b };
+}
+
 export function angleFromTo(a: Position, b: Position) {
     return (Math.atan2(a.y-b.y, b.x-a.x) + Math.PI * 2) % (Math.PI * 2);
 }

--- a/packages/server/src/vector.ts
+++ b/packages/server/src/vector.ts
@@ -28,6 +28,10 @@ export function sum(a: Position, b: Position) {
     return {x: a.x + b.x, y: a.y + b.y };
 }
 
+export function sumScalar(a: Position, b: number) {
+    return { x: a.x + b, y: a.y + b };
+}
+
 export function mul(a: Position, b: number) {
     return {x: a.x * b, y: a.y * b };
 }


### PR DESCRIPTION
This PR directly addresses #39 by changing pathfinding to allow for two types of "destinations" - units and map locations. For units, special logic in game.ts:515-525 determines whether the unit is a building, and if so instructs the pathfinder to find a path towards any path taken by the building (which will effectively only consider extents anyway).

Some small changes and refactorings include renaming "Action" to "Command" and removing `UnitState` and the "State" logic completely, replacing them with `MatchMetadata`.